### PR TITLE
Fix comment encoding

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,21 +3,21 @@ spring.datasource.username=postgres
 spring.datasource.password=postgres
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# ????????? JPA
+# Настройки JPA
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.default_schema=public
 
-# ????????? ???????????
+# Настройки логирования
 logging.level.org.hibernate=ERROR
 logging.level.org.hibernate.SQL=OFF
 logging.level.org.hibernate.type.descriptor.sql=OFF
 logging.level.org.springframework=INFO
 spring.jpa.open-in-view=false
 
-# ????????? Telegram ????
+# Параметры Telegram бота
 bot.username=${BOT_USERNAME:GeoGreet_bot}
 bot.token=${BOT_TOKEN}
 yandex.api.key=${YANDEX_API_KEY}


### PR DESCRIPTION
## Summary
- convert `application.properties` to UTF-8
- use readable Russian comments for logging, JPA, and bot settings

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bdb4c670833080cfd4b213051b36