### PR TITLE
chore(ci): run clean test for backend

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -67,7 +67,7 @@ jobs:
           java-version: 17
           cache: maven
       - name: Run backend tests with coverage
-        run: mvn -B -ntp -f apps/backend/pom.xml test
+        run: mvn -B -ntp -f apps/backend/pom.xml clean test
       - name: Install diff-cover
         if: github.event_name == 'pull_request'
         run: python -m pip install diff-cover==9.1.1


### PR DESCRIPTION
## Summary
- update ci-lite backend job to call mvn clean test to avoid stale class duplicates

## Testing
- mvn -f apps/backend/pom.xml clean test
