### PR TITLE
feat(backend): add mini app swipe and profile stubs

### DIFF
--- a/apps/backend/src/main/java/com/example/dating/backend/api/profiles/MiniAppProfileService.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/profiles/MiniAppProfileService.java
@@ -1,0 +1,66 @@
+package com.example.dating.backend.api.profiles;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MiniAppProfileService {
+
+    private final Map<Long, ProfileResponse> profiles = new ConcurrentHashMap<>();
+
+    public MiniAppProfileService() {
+        ProfileResponse seed = new ProfileResponse(
+            111111L,
+            "Алекс",
+            "Люблю путешествия и вечерние прогулки",
+            List.of("музыка", "спорт"),
+            LocalDate.of(1995, 5, 12),
+            new ProfileLocation("Москва", 55.751244, 37.618423),
+            Instant.now()
+        );
+        profiles.put(seed.telegramId(), seed);
+    }
+
+    public ProfileResponse fetchProfile(Long telegramId) {
+        return profiles.computeIfAbsent(telegramId, this::createBlankProfile);
+    }
+
+    public ProfileResponse updateProfile(Long telegramId, ProfileUpdateRequest request) {
+        ProfileLocation location = buildLocation(request);
+        ProfileResponse updated = new ProfileResponse(
+            telegramId,
+            request.displayName(),
+            request.bio(),
+            request.interests() == null ? List.of() : List.copyOf(request.interests()),
+            request.birthday(),
+            location,
+            Instant.now()
+        );
+        profiles.put(telegramId, updated);
+        return updated;
+    }
+
+    private ProfileResponse createBlankProfile(Long telegramId) {
+        return new ProfileResponse(
+            telegramId,
+            "Новый пользователь",
+            "",
+            new ArrayList<>(),
+            null,
+            null,
+            Instant.now()
+        );
+    }
+
+    private ProfileLocation buildLocation(ProfileUpdateRequest request) {
+        if (request.city() == null && request.latitude() == null && request.longitude() == null) {
+            return null;
+        }
+        return new ProfileLocation(request.city(), request.latitude(), request.longitude());
+    }
+}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/profiles/ProfileLocation.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/profiles/ProfileLocation.java
@@ -1,0 +1,7 @@
+package com.example.dating.backend.api.profiles;
+
+public record ProfileLocation(
+    String city,
+    Double latitude,
+    Double longitude
+) {}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/profiles/ProfileResponse.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/profiles/ProfileResponse.java
@@ -1,0 +1,15 @@
+package com.example.dating.backend.api.profiles;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+public record ProfileResponse(
+    Long telegramId,
+    String name,
+    String bio,
+    List<String> interests,
+    LocalDate birthday,
+    ProfileLocation location,
+    Instant updatedAt
+) {}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/swipes/MiniAppSwipeController.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/swipes/MiniAppSwipeController.java
@@ -1,0 +1,34 @@
+package com.example.dating.backend.api.swipes;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/swipes")
+public class MiniAppSwipeController {
+
+    private final MiniAppSwipeService swipeService;
+
+    public MiniAppSwipeController(MiniAppSwipeService swipeService) {
+        this.swipeService = swipeService;
+    }
+
+    @GetMapping("/queue")
+    public ResponseEntity<SwipeQueue> getQueue(@RequestHeader("x-telegram-user-id") Long telegramUserId) {
+        return ResponseEntity.ok(swipeService.fetchQueue(telegramUserId));
+    }
+
+    @PostMapping
+    public ResponseEntity<SwipeResponse> swipe(
+        @RequestHeader("x-telegram-user-id") Long telegramUserId,
+        @Valid @RequestBody SwipeRequest request
+    ) {
+        return ResponseEntity.ok(swipeService.processSwipe(telegramUserId, request));
+    }
+}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/swipes/MiniAppSwipeService.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/swipes/MiniAppSwipeService.java
@@ -1,0 +1,63 @@
+package com.example.dating.backend.api.swipes;
+
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+import com.example.dating.backend.api.profiles.ProfileLocation;
+import com.example.dating.backend.api.profiles.ProfileResponse;
+
+@Service
+public class MiniAppSwipeService {
+
+    private final Map<Long, Deque<SwipeQueueItem>> swipeQueues = new ConcurrentHashMap<>();
+
+    public MiniAppSwipeService() {
+        // seed queue for demo
+        Deque<SwipeQueueItem> queue = new ArrayDeque<>();
+        queue.add(new SwipeQueueItem(
+            new ProfileResponse(
+                222222L,
+                "Катя",
+                "Играю на пианино",
+                List.of("музыка", "путешествия"),
+                null,
+                new ProfileLocation("Москва", 55.75222, 37.61556),
+                Instant.now()
+            ),
+            1.2
+        ));
+        queue.add(new SwipeQueueItem(
+            new ProfileResponse(
+                333333L,
+                "Сергей",
+                "Бег и кофе",
+                List.of("спорт"),
+                null,
+                new ProfileLocation("Москва", 55.76222, 37.62556),
+                Instant.now()
+            ),
+            2.5
+        ));
+        swipeQueues.put(111111L, queue);
+    }
+
+    public SwipeQueue fetchQueue(Long telegramId) {
+        Deque<SwipeQueueItem> queue = swipeQueues.computeIfAbsent(telegramId, key -> new ArrayDeque<>());
+        return new SwipeQueue(new ArrayList<>(queue));
+    }
+
+    public SwipeResponse processSwipe(Long telegramId, SwipeRequest request) {
+        Deque<SwipeQueueItem> queue = swipeQueues.computeIfAbsent(telegramId, key -> new ArrayDeque<>());
+        queue.removeIf(item -> item.profile().telegramId().equals(request.targetTelegramId()));
+
+        boolean matched = request.direction() != SwipeDirection.DISLIKE && request.targetTelegramId() % 2 == 0;
+        return new SwipeResponse(matched, matched ? "match-" + telegramId + "-" + request.targetTelegramId() : null, Instant.now());
+    }
+}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeDirection.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeDirection.java
@@ -1,0 +1,7 @@
+package com.example.dating.backend.api.swipes;
+
+public enum SwipeDirection {
+    LIKE,
+    DISLIKE,
+    SUPERLIKE
+}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeQueue.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeQueue.java
@@ -1,0 +1,5 @@
+package com.example.dating.backend.api.swipes;
+
+import java.util.List;
+
+public record SwipeQueue(List<SwipeQueueItem> items) {}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeQueueItem.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeQueueItem.java
@@ -1,0 +1,8 @@
+package com.example.dating.backend.api.swipes;
+
+import com.example.dating.backend.api.profiles.ProfileResponse;
+
+public record SwipeQueueItem(
+    ProfileResponse profile,
+    Double distanceKm
+) {}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeRequest.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeRequest.java
@@ -1,0 +1,8 @@
+package com.example.dating.backend.api.swipes;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SwipeRequest(
+    @NotNull Long targetTelegramId,
+    @NotNull SwipeDirection direction
+) {}

--- a/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeResponse.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/api/swipes/SwipeResponse.java
@@ -1,0 +1,9 @@
+package com.example.dating.backend.api.swipes;
+
+import java.time.Instant;
+
+public record SwipeResponse(
+    boolean matched,
+    String matchId,
+    Instant createdAt
+) {}

--- a/apps/backend/src/main/java/com/example/dating/backend/profile/ProfileController.java
+++ b/apps/backend/src/main/java/com/example/dating/backend/profile/ProfileController.java
@@ -1,0 +1,33 @@
+package com.example.dating.backend.profile;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/profile")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final ProfileService service;
+
+    @GetMapping("/me")
+    public ProfileResponse me(Authentication authentication) {
+        Long telegramId = Long.parseLong(authentication.getName());
+        return service.fetchProfile(telegramId);
+    }
+
+    @PutMapping
+    public ProfileResponse update(
+        Authentication authentication,
+        @Valid @RequestBody UpdateProfileRequest request
+    ) {
+        Long telegramId = Long.parseLong(authentication.getName());
+        return service.upsertProfile(telegramId, request);
+    }
+}

--- a/apps/miniapp-gateway/src/modules/swipes/types/swipe.queue.response.ts
+++ b/apps/miniapp-gateway/src/modules/swipes/types/swipe.queue.response.ts
@@ -1,0 +1,10 @@
+import type { ProfileResponse } from '../../profiles/types/profile.response'
+
+export interface SwipeQueueItem {
+  profile: ProfileResponse
+  distanceKm?: number | null
+}
+
+export interface SwipeQueueResponse {
+  items: SwipeQueueItem[]
+}


### PR DESCRIPTION
## Summary
- add in-memory mini app profile service to back Telegram mini app drafts
- expose queue-based swipe endpoints with seeded data for prototyping
- align backend DTOs with gateway types (new swipe queue response interface)

## Testing
- mvn -f apps/backend/pom.xml test
