### PR TITLE
feat(frontend): refresh swipe card experience

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.0.1",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -31,6 +32,13 @@
         "vite": "^5.0.0",
         "vitest": "^2.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -1455,6 +1463,33 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
@@ -2512,6 +2547,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -3968,6 +4010,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4739,6 +4791,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -5290,6 +5352,20 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5871,6 +5947,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -17,6 +17,8 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.0.1",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@typescript-eslint/eslint-plugin": "^8.44.1",
@@ -30,7 +32,6 @@
     "jsdom": "^25.0.1",
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
-    "vitest": "^2.1.4",
-    "@testing-library/react": "^16.0.1"
+    "vitest": "^2.1.4"
   }
 }

--- a/apps/frontend/src/__tests__/UserCard.test.tsx
+++ b/apps/frontend/src/__tests__/UserCard.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import UserCard from '../components/UserCard';
+
+describe('UserCard', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders skeleton state when loading', () => {
+    const { container } = render(<UserCard isLoading onLike={() => {}} onSkip={() => {}} />);
+    expect(container.querySelector('[data-loading="true"]')).toBeInTheDocument();
+  });
+
+  it('renders placeholder when username missing', () => {
+    render(<UserCard onLike={() => {}} onSkip={() => {}} />);
+    expect(screen.getByText('Нет анкет поблизости')).toBeInTheDocument();
+  });
+
+  it('renders photos with pagination and allows manual selection', () => {
+    render(
+      <UserCard
+        username="Мария"
+        age={27}
+        photos={[
+          'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=400&q=80',
+          'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=400&q=80',
+        ]}
+        bio="Люблю путешествия и кофе."
+        interests={['еда', 'кино']}
+        onLike={() => {}}
+        onSkip={() => {}}
+      />,
+    );
+
+    const dots = screen.getAllByRole('button', { name: /Фото \d+ из 2/ });
+    expect(dots).toHaveLength(2);
+    expect(dots[0].getAttribute('data-active')).toBe('true');
+
+    fireEvent.click(dots[1]);
+    expect(dots[1].getAttribute('data-active')).toBe('true');
+    expect(dots[0].getAttribute('data-active')).toBe('false');
+  });
+
+  it('triggers like and skip handlers', () => {
+    const handleLike = vi.fn();
+    const handleSkip = vi.fn();
+
+    render(
+      <UserCard
+        username='Олег'
+        photos={['https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=400&q=80']}
+        onLike={handleLike}
+        onSkip={handleSkip}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Лайк' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Пропустить' }));
+
+    expect(handleLike).toHaveBeenCalledTimes(1);
+    expect(handleSkip).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/components/UserCard.module.css
+++ b/apps/frontend/src/components/UserCard.module.css
@@ -1,0 +1,281 @@
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-width: var(--size-card-max-width);
+  margin: 0 auto;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-elevated);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  color: var(--color-text-primary);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.card[data-dragging='true'] {
+  cursor: grabbing;
+  box-shadow: var(--shadow-sm), 0 12px 32px var(--color-overlay-soft);
+}
+
+.media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  overflow: hidden;
+  background: var(--color-surface);
+  touch-action: pan-y;
+}
+
+.mediaTrack {
+  display: flex;
+  height: 100%;
+  transition: transform var(--transition-base);
+}
+
+.mediaTrack[data-dragging='true'] {
+  transition: none;
+}
+
+.photo {
+  flex: 0 0 100%;
+  width: 100%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
+.photoPlaceholder {
+  flex: 0 0 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--color-overlay-soft), var(--color-overlay-medium));
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-lg);
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 55%, rgba(0, 0, 0, 0.6) 100%);
+  pointer-events: none;
+}
+
+.header {
+  position: absolute;
+  left: var(--space-md);
+  right: var(--space-md);
+  bottom: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  color: var(--color-text-invert);
+  z-index: 1;
+}
+
+.title {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-xs);
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+  font-size: var(--font-size-sm);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: rgba(0, 0, 0, 0.45);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.pagination {
+  position: absolute;
+  top: var(--space-sm);
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border: none;
+  padding: 0;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.32);
+  cursor: pointer;
+  transition: transform var(--transition-base), background var(--transition-base);
+}
+
+.dot:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.dot[data-active='true'] {
+  background: var(--color-accent-contrast);
+  transform: scale(1.2);
+}
+
+.dot[disabled] {
+  cursor: default;
+  border-radius: 50%;
+  opacity: 0.36;
+}
+
+.body {
+  padding: var(--space-lg) var(--space-xl) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.bio {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  background: var(--color-overlay-soft);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--space-md) var(--space-xl) var(--space-lg);
+  gap: var(--space-sm);
+  background: var(--color-surface);
+}
+
+.btn {
+  width: var(--size-action-button);
+  height: var(--size-action-button);
+  border: none;
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-lg);
+  cursor: pointer;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-xs);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), background var(--transition-base), color var(--transition-base);
+}
+
+.btnLike {
+  color: var(--color-like);
+}
+
+.btnSkip {
+  color: var(--color-skip);
+}
+
+.btn:active {
+  transform: scale(0.94);
+  box-shadow: none;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: var(--space-xl);
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.placeholderTitle {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+
+.placeholderText {
+  margin: 0;
+  font-size: var(--font-size-sm);
+}
+
+.skeletonBlock {
+  border-radius: var(--radius-md);
+  background: linear-gradient(90deg, var(--color-overlay-soft) 25%, var(--color-overlay-medium) 50%, var(--color-overlay-soft) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.2s ease-in-out infinite;
+}
+
+.skeletonMedia {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+}
+
+.skeletonTitle {
+  width: 60%;
+  height: 20px;
+}
+
+.skeletonText {
+  width: 90%;
+  height: 12px;
+}
+
+.skeletonActions {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  width: 100%;
+}
+
+.skeletonCircle {
+  width: var(--size-action-button);
+  height: var(--size-action-button);
+  border-radius: var(--radius-pill);
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}

--- a/apps/frontend/src/components/UserCard.tsx
+++ b/apps/frontend/src/components/UserCard.tsx
@@ -1,49 +1,255 @@
-import { memo } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import styles from './UserCard.module.css';
 
 interface UserCardProps {
-  username: string;
+  username?: string;
+  age?: number;
   bio?: string;
+  interests?: string[];
+  photos?: string[];
+  distanceKm?: number;
+  isLoading?: boolean;
   onLike: () => void;
   onSkip: () => void;
 }
 
-function UserCard({ username, bio, onLike, onSkip }: UserCardProps) {
-  const tg = (window as any).Telegram?.WebApp;
-  const haptic = (type: 'like' | 'skip') =>
-    tg?.HapticFeedback?.impactOccurred(type === 'like' ? 'soft' : 'light');
+const SWIPE_THRESHOLD_RATIO = 0.18;
+const MAX_INTERESTS = 6;
 
+const join = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(' ');
+
+const formatDistance = (distanceKm?: number) => {
+  if (typeof distanceKm !== 'number' || Number.isNaN(distanceKm)) return undefined;
+  if (distanceKm < 1) {
+    return `${Math.round(distanceKm * 1000)} м`;
+  }
+  return `${Math.round(distanceKm)} км`;
+};
+
+function SkeletonCard() {
   return (
-    <div className="card" role="group" aria-label={`Анкета ${username}`}>
-      <div className="card-body">
-        <h2>{username}</h2>
-        {bio && <p>{bio}</p>}
+    <div className={styles.card} data-loading="true">
+      <div className={join(styles.skeletonBlock, styles.skeletonMedia)} />
+      <div className={styles.body}>
+        <div className={join(styles.skeletonBlock, styles.skeletonTitle)} />
+        <div className={join(styles.skeletonBlock, styles.skeletonText)} />
+        <div className={join(styles.skeletonBlock, styles.skeletonText)} style={{ width: '70%' }} />
       </div>
-      <div className="card-actions">
-        <button
-          type="button"
-          className="btn skip"
-          onClick={() => {
-            haptic('skip');
-            onSkip();
-          }}
-        >
+      <div className={join(styles.actions, styles.skeletonActions)}>
+        <div className={join(styles.skeletonBlock, styles.skeletonCircle)} />
+        <div className={join(styles.skeletonBlock, styles.skeletonCircle)} />
+      </div>
+    </div>
+  );
+}
+
+function PlaceholderCard() {
+  return (
+    <div className={styles.card} data-placeholder="true">
+      <div className={styles.placeholder}>
+        <h2 className={styles.placeholderTitle}>Нет анкет поблизости</h2>
+        <p className={styles.placeholderText}>Попробуйте обновить или расширить радиус поиска.</p>
+      </div>
+      <div className={styles.actions}>
+        <button type="button" className={styles.btn} disabled aria-hidden>
           ✖
-          <span className="visually-hidden">Пропустить</span>
         </button>
-        <button
-          type="button"
-          className="btn like"
-          onClick={() => {
-            haptic('like');
-            onLike();
-          }}
-        >
+        <button type="button" className={styles.btn} disabled aria-hidden>
           ❤
-          <span className="visually-hidden">Лайк</span>
         </button>
       </div>
     </div>
   );
 }
 
-export default memo(UserCard);
+function UserCardComponent({
+  username,
+  age,
+  bio,
+  interests = [],
+  photos = [],
+  distanceKm,
+  isLoading = false,
+  onLike,
+  onSkip,
+}: UserCardProps) {
+  const tg = (window as any).Telegram?.WebApp;
+  const [activePhoto, setActivePhoto] = useState(0);
+  const [dragRatio, setDragRatio] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const startXRef = useRef<number | null>(null);
+  const pointerIdRef = useRef<number | null>(null);
+  const widthRef = useRef<number>(1);
+  const mediaRef = useRef<HTMLDivElement | null>(null);
+
+  const safePhotos = useMemo(() => photos.filter(Boolean), [photos]);
+  const displayedInterests = useMemo(
+    () => interests.filter(Boolean).slice(0, MAX_INTERESTS),
+    [interests],
+  );
+  const distanceLabel = formatDistance(distanceKm);
+
+  useEffect(() => {
+    setActivePhoto(0);
+  }, [safePhotos.length]);
+
+  if (isLoading) {
+    return <SkeletonCard />;
+  }
+
+  if (!username) {
+    return <PlaceholderCard />;
+  }
+
+  const totalPhotos = safePhotos.length;
+  const transformed = `translateX(${(-activePhoto + (isDragging ? dragRatio : 0)) * 100}%)`;
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (totalPhotos <= 1) return;
+    pointerIdRef.current = event.pointerId;
+    startXRef.current = event.clientX;
+    widthRef.current = mediaRef.current?.clientWidth ?? event.currentTarget.clientWidth;
+    setIsDragging(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging || startXRef.current === null) return;
+    const delta = event.clientX - startXRef.current;
+    const rawRatio = delta / widthRef.current;
+    const clampedRatio = Math.max(Math.min(rawRatio, 0.4), -0.4);
+    setDragRatio(clampedRatio);
+  };
+
+  const completeSwipe = () => {
+    if (!isDragging) return;
+    const ratio = dragRatio;
+    let nextIndex = activePhoto;
+
+    if (ratio <= -SWIPE_THRESHOLD_RATIO && activePhoto < totalPhotos - 1) {
+      nextIndex = activePhoto + 1;
+    } else if (ratio >= SWIPE_THRESHOLD_RATIO && activePhoto > 0) {
+      nextIndex = activePhoto - 1;
+    }
+
+    if (nextIndex !== activePhoto) {
+      setActivePhoto(nextIndex);
+      tg?.HapticFeedback?.impactOccurred('light');
+    }
+
+    setDragRatio(0);
+    setIsDragging(false);
+    startXRef.current = null;
+    pointerIdRef.current = null;
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (pointerIdRef.current !== null && event.currentTarget.hasPointerCapture(pointerIdRef.current)) {
+      event.currentTarget.releasePointerCapture(pointerIdRef.current);
+    }
+    completeSwipe();
+  };
+
+  const handlePointerCancel = () => {
+    completeSwipe();
+  };
+
+  const handleDotClick = (index: number) => {
+    setActivePhoto(index);
+    tg?.HapticFeedback?.impactOccurred('light');
+  };
+
+  const handleLike = () => {
+    tg?.HapticFeedback?.impactOccurred('soft');
+    onLike();
+  };
+
+  const handleSkip = () => {
+    tg?.HapticFeedback?.impactOccurred('light');
+    onSkip();
+  };
+
+  return (
+    <div className={styles.card} data-dragging={isDragging}>
+      {totalPhotos > 0 ? (
+        <div
+          ref={mediaRef}
+          className={styles.media}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
+        >
+          <div className={styles.mediaTrack} data-dragging={isDragging} style={{ transform: transformed }}>
+            {safePhotos.map((src, index) => (
+              <img key={src || index} src={src} alt="" className={styles.photo} draggable={false} />
+            ))}
+          </div>
+          <div className={styles.overlay} aria-hidden />
+          <div className={styles.header}>
+            <div className={styles.title}>
+              <span>{username}</span>
+              {typeof age === 'number' && !Number.isNaN(age) && <span>{age}</span>}
+            </div>
+            <div className={styles.meta}>
+              {distanceLabel && <span>{distanceLabel} от вас</span>}
+              {totalPhotos > 1 && <span className={styles.badge}>фото {activePhoto + 1}/{totalPhotos}</span>}
+            </div>
+          </div>
+          {totalPhotos > 1 && (
+            <div className={styles.pagination} aria-label="Переключение фото">
+              {safePhotos.map((_, index) => (
+                <button
+                  key={index}
+                  type="button"
+                  className={styles.dot}
+                  data-active={index === activePhoto}
+                  onClick={() => handleDotClick(index)}
+                  aria-label={`Фото ${index + 1} из ${totalPhotos}`}
+                  aria-pressed={index === activePhoto}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className={styles.media}>
+          <div className={styles.photoPlaceholder}>Фото появятся позже</div>
+          <div className={styles.overlay} aria-hidden />
+          <div className={styles.header}>
+            <div className={styles.title}>
+              <span>{username}</span>
+              {typeof age === 'number' && !Number.isNaN(age) && <span>{age}</span>}
+            </div>
+            {distanceLabel && <div className={styles.meta}>{distanceLabel} от вас</div>}
+          </div>
+        </div>
+      )}
+
+      <div className={styles.body}>
+        {bio ? <p className={styles.bio}>{bio}</p> : <p className={styles.bio}>Аватар скоро обновится. Скажите «привет» и узнайте друг друга ближе.</p>}
+        {displayedInterests.length > 0 && (
+          <ul className={styles.tags}>
+            {displayedInterests.map((interest) => (
+              <li key={interest} className={styles.tag}>
+                #{interest}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className={styles.actions}>
+        <button type="button" className={join(styles.btn, styles.btnSkip)} onClick={handleSkip} aria-label="Пропустить">
+          ✖
+        </button>
+        <button type="button" className={join(styles.btn, styles.btnLike)} onClick={handleLike} aria-label="Лайк">
+          ❤
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default memo(UserCardComponent);

--- a/apps/frontend/src/custom.d.ts
+++ b/apps/frontend/src/custom.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: Record<string, string>;
+  export default classes;
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -80,85 +80,12 @@ nav a:focus-visible {
   }
 }
 
-.card {
-  max-width: var(--size-card-max-width);
-  margin: 0 auto;
-  background: var(--color-surface-elevated);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
-  overflow: hidden;
-  text-align: center;
-  color: var(--color-text-primary);
-}
 
-.card-body {
-  padding: var(--space-lg);
-}
-
-.card-body h2 {
-  margin: 0 0 var(--space-sm);
-  font-size: var(--font-size-lg);
-  line-height: var(--line-height-tight);
-}
-
-.card-body p {
-  margin: 0;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
-}
-
-.card-actions {
+.discovery-card {
   display: flex;
-  justify-content: space-between;
-  padding: var(--space-md) var(--space-xl);
-  gap: var(--space-sm);
-  background: var(--color-surface);
-}
-
-.btn {
-  width: var(--size-action-button);
-  height: var(--size-action-button);
-  border: none;
-  border-radius: var(--radius-pill);
-  font-size: var(--font-size-lg);
-  cursor: pointer;
-  background: var(--color-surface);
-  color: var(--color-text-primary);
-  display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  box-shadow: var(--shadow-xs);
-  transition: transform var(--transition-base), box-shadow var(--transition-base), background var(--transition-base), color var(--transition-base);
-}
-
-.btn.like {
-  color: var(--color-like);
-}
-
-.btn.skip {
-  color: var(--color-skip);
-}
-
-.btn:active {
-  transform: scale(0.94);
-  box-shadow: none;
-}
-
-.btn:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  gap: var(--space-lg);
 }
 
 .toast-container {

--- a/apps/frontend/src/pages/DiscoveryPage.tsx
+++ b/apps/frontend/src/pages/DiscoveryPage.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import Loader from '../components/Loader';
 import UserCard from '../components/UserCard';
 import { useAuthStore } from '../store/useAuthStore';
 import { useToastStore } from '../store/useToastStore';
 
 interface Profile {
   userId: number;
-  user: { username: string };
+  user: {
+    username: string;
+    age?: number;
+    photos?: string[];
+    interests?: string[];
+  };
   bio?: string;
+  age?: number;
+  interests?: string[];
+  photos?: string[];
+  distanceKm?: number;
 }
 
 export default function DiscoveryPage() {
@@ -49,10 +57,37 @@ export default function DiscoveryPage() {
     },
   });
 
-  if (isLoading || !data) return <Loader />;
-  if (data.length === 0) return <main>Никого рядом 😔</main>;
+  if (isLoading || !data) {
+    return (
+      <div className="discovery-card">
+        <UserCard
+          isLoading
+          onLike={() => {}}
+          onSkip={() => {}}
+        />
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="discovery-card">
+        <UserCard onLike={() => {}} onSkip={refetch} />
+      </div>
+    );
+  }
 
   const profile = data[0];
+  const photos = profile.photos?.length
+    ? profile.photos
+    : profile.user.photos?.length
+      ? profile.user.photos
+      : [];
+  const interests = profile.interests?.length
+    ? profile.interests
+    : profile.user.interests?.length
+      ? profile.user.interests
+      : [];
 
   const handleSkip = () => {
     showToast('Пропущено');
@@ -60,13 +95,17 @@ export default function DiscoveryPage() {
   };
 
   return (
-    <main>
+    <div className="discovery-card">
       <UserCard
         username={profile.user.username}
+        age={profile.age ?? profile.user.age}
         bio={profile.bio}
+        interests={interests}
+        photos={photos}
+        distanceKm={profile.distanceKm}
         onLike={() => like.mutate(profile.userId)}
         onSkip={handleSkip}
       />
-    </main>
+    </div>
   );
 }

--- a/apps/frontend/src/setupTests.ts
+++ b/apps/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/apps/frontend/src/theme/tokens.ts
+++ b/apps/frontend/src/theme/tokens.ts
@@ -91,6 +91,7 @@ function resolveColors(params: TelegramThemeParams = {}): ThemeTokenMap {
   const borderStrong = toRgba(textPrimary, 0.16);
   const skipColor = toRgba(textPrimary, 0.45);
   const overlaySoft = toRgba(textPrimary, 0.05);
+  const overlayMedium = toRgba(textPrimary, 0.16);
   const overlayStrong = toRgba(textPrimary, 0.8);
 
   return {
@@ -109,6 +110,7 @@ function resolveColors(params: TelegramThemeParams = {}): ThemeTokenMap {
     '--color-skip': skipColor,
     '--color-danger': destructive,
     '--color-overlay-soft': overlaySoft,
+    '--color-overlay-medium': overlayMedium,
     '--color-overlay-strong': overlayStrong,
     '--color-toast-background': overlayStrong,
     '--shadow-xs': `0 1px 2px ${toRgba(textPrimary, 0.08)}`,

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["vitest/globals", "vite/client"]
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"]
   },
   "include": [
     "src",

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   server: { port: 5173 },
   test: {
     globals: true,
-    environment: 'jsdom'
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts'
   }
 });


### PR DESCRIPTION
## Summary
- add themed swipe card UI with photo carousel, badges, and gradients
- wire discovery page to skeleton/placeholder states and new card props
- add vitest coverage for card interactions and setup jest-dom

## Testing
- npm run lint
- npm run typecheck
- npm run test

Closes #60