### PR TITLE
feat(frontend): redesign onboarding wizard

### DIFF
--- a/apps/frontend/src/__tests__/OnboardingPage.test.tsx
+++ b/apps/frontend/src/__tests__/OnboardingPage.test.tsx
@@ -1,0 +1,108 @@
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import OnboardingPage from '../pages/OnboardingPage';
+import { useToastStore } from '../store/useToastStore';
+
+const LocationDisplay = () => {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}</div>;
+};
+
+const renderOnboarding = () =>
+  render(
+    <MemoryRouter initialEntries={['/onboarding']}>
+      <Routes>
+        <Route path="/onboarding" element={<OnboardingPage />} />
+        <Route path="/" element={<div>Home</div>} />
+      </Routes>
+      <LocationDisplay />
+    </MemoryRouter>,
+  );
+
+describe('OnboardingPage', () => {
+  const originalFetch = globalThis.fetch;
+  const originalGeolocation = navigator.geolocation;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: (_success?: PositionCallback, error?: PositionErrorCallback) => {
+          error?.({} as GeolocationPositionError);
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: originalGeolocation,
+    });
+  });
+
+  it('validates first step before continuing', async () => {
+    const toastSpy = vi.spyOn(useToastStore.getState(), 'show');
+    renderOnboarding();
+    await screen.findByText('Основные данные');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Далее' }));
+
+    await waitFor(() => expect(toastSpy).toHaveBeenCalled());
+    expect(screen.getByText('Основные данные')).toBeInTheDocument();
+  });
+
+  it('walks through steps with valid data', async () => {
+    renderOnboarding();
+    await screen.findByText('Основные данные');
+
+    fireEvent.change(screen.getByLabelText('Имя или никнейм'), { target: { value: 'Анна' } });
+    const birthDate = new Date();
+    birthDate.setFullYear(birthDate.getFullYear() - 25);
+    fireEvent.change(screen.getByLabelText('Дата рождения'), {
+      target: { value: birthDate.toISOString().split('T')[0] },
+    });
+    fireEvent.change(screen.getByLabelText('Пол'), { target: { value: 'female' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Далее' }));
+    expect(await screen.findByText('Добавьте фото')).toBeInTheDocument();
+
+    const file = new File(['data'], 'photo.png', { type: 'image/png' });
+    const fileInput = screen.getByLabelText(/Загрузите/, { selector: 'input' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByAltText('photo.png')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Далее' }));
+    expect(await screen.findByText('Интересы и цели')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('О себе'), { target: { value: 'Люблю путешествовать и фотографировать.' } });
+    fireEvent.change(screen.getByLabelText('Интересы (через запятую)'), { target: { value: 'путешествия,музыка' } });
+    fireEvent.change(screen.getByLabelText('Цели знакомства'), { target: { value: 'Серьёзные отношения' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Далее' }));
+
+    expect(await screen.findByText('География знакомств')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Указать вручную' }));
+    fireEvent.change(screen.getByLabelText('Город'), { target: { value: 'Москва' } });
+    fireEvent.change(screen.getByLabelText('Радиус поиска (км)'), { target: { value: '15' } });
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Москва')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('15')).toBeInTheDocument();
+    });
+
+    const fetchMock = globalThis.fetch as unknown as Mock;
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce({ ok: true });
+    fetchMock.mockResolvedValueOnce({ ok: true });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Завершить' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId('location-display').textContent).toBe('/'));
+  });
+});

--- a/apps/frontend/src/pages/OnboardingPage.module.css
+++ b/apps/frontend/src/pages/OnboardingPage.module.css
@@ -15,6 +15,12 @@
   gap: var(--space-md);
 }
 
+.stepCaption {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
 .progress {
   display: flex;
   justify-content: center;
@@ -38,6 +44,73 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+}
+
+.twoColumns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-sm);
+}
+
+.photoGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-sm);
+}
+
+.photoTile {
+  position: relative;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-overlay-soft);
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: var(--space-sm);
+}
+
+.photoTile img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.photoRemove {
+  position: absolute;
+  top: var(--space-2xs);
+  right: var(--space-2xs);
+  border: none;
+  border-radius: var(--radius-pill);
+  background: rgba(0, 0, 0, 0.55);
+  color: var(--color-accent-contrast);
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.photoUpload {
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  text-align: center;
+  padding: var(--space-sm);
+}
+
+.photoUpload input {
+  display: none;
 }
 
 .label {
@@ -99,6 +172,23 @@
 .helper {
   margin: 0;
   font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.error {
+  font-size: var(--font-size-xs);
+  color: var(--color-danger);
+  margin: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border-radius: var(--radius-pill);
+  background: var(--color-overlay-soft);
+  font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
 }
 

--- a/apps/frontend/src/pages/OnboardingPage.tsx
+++ b/apps/frontend/src/pages/OnboardingPage.tsx
@@ -1,41 +1,128 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styles from './OnboardingPage.module.css';
 import { useToastStore } from '../store/useToastStore';
 import { useAuthStore } from '../store/useAuthStore';
 import DeviceStorage, { DeviceStorageError } from '../utils/deviceStorage';
 
-interface OnboardingDraft {
+const DRAFT_KEY = 'onboarding-draft';
+const MAX_PHOTOS = 6;
+const MIN_NAME_LENGTH = 2;
+const MIN_AGE = 18;
+const MAX_PHOTO_SIZE = 1 * 1024 * 1024; // 1 MB per photo
+
+type Gender = 'male' | 'female' | 'other' | '';
+
+type LocationMode = 'auto' | 'manual';
+
+type PhotoDraft = {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+  dataUrl: string;
+};
+
+type OnboardingDraft = {
   step: number;
   name: string;
+  birthDate: string;
+  gender: Gender;
   bio: string;
   interests: string;
   goals: string;
-}
-
-const DRAFT_KEY = 'onboarding-draft';
+  photos: PhotoDraft[];
+  locationMode: LocationMode;
+  radiusKm: number;
+  city: string;
+  geo?: {
+    lat: number;
+    lon: number;
+  };
+};
 
 const defaultDraft: OnboardingDraft = {
   step: 0,
   name: '',
+  birthDate: '',
+  gender: '',
   bio: '',
   interests: '',
   goals: '',
+  photos: [],
+  locationMode: 'auto',
+  radiusKm: 10,
+  city: '',
+  geo: undefined,
 };
+
+const calculateAge = (birthDate: string) => {
+  if (!birthDate) return 0;
+  const birth = new Date(birthDate);
+  if (Number.isNaN(birth.getTime())) return 0;
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age -= 1;
+  }
+  return age;
+};
+
+const decodeBase64 = (base64: string) => {
+  if (typeof window !== 'undefined' && typeof window.atob === 'function') {
+    const binary = window.atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  if (typeof globalThis.Buffer !== 'undefined') {
+    return Uint8Array.from(globalThis.Buffer.from(base64, 'base64'));
+  }
+
+  throw new Error('Base64 decoding is not supported in this environment');
+};
+
+const dataUrlToFile = async (photo: PhotoDraft): Promise<File> => {
+  const [meta, data] = photo.dataUrl.split(',');
+  if (!meta || !data) {
+    throw new Error('Некорректный формат изображения');
+  }
+  const mimeMatch = /data:(.*);base64/.exec(meta);
+  const mimeType = mimeMatch ? mimeMatch[1] : photo.type;
+  const buffer = decodeBase64(data);
+  return new File([buffer], photo.name, { type: mimeType });
+};
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error('Не удалось прочитать файл'));
+    reader.readAsDataURL(file);
+  });
 
 export default function OnboardingPage() {
   const showToast = useToastStore((s) => s.show);
   const token = useAuthStore((s) => s.token);
+  const navigate = useNavigate();
   const [draft, setDraft] = useState<OnboardingDraft>(defaultDraft);
   const [isLoadingDraft, setIsLoadingDraft] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDetectingLocation, setIsDetectingLocation] = useState(false);
 
   const authHeaders = useMemo<HeadersInit>(
     () => ({
-      'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      'Content-Type': 'application/json',
     }),
     [token],
   );
+
+  const mediaHeaders = useMemo<HeadersInit>(() => ({ ...(token ? { Authorization: `Bearer ${token}` } : {}) }), [token]);
 
   useEffect(() => {
     let cancelled = false;
@@ -60,6 +147,32 @@ export default function OnboardingPage() {
     };
   }, [showToast]);
 
+  useEffect(() => {
+    if (draft.locationMode !== 'auto' || draft.geo || isDetectingLocation) return;
+    if (!('geolocation' in navigator)) {
+      showToast('Геолокация недоступна, заполните город вручную');
+      setDraft((prev) => ({ ...prev, locationMode: 'manual' }));
+      return;
+    }
+    setIsDetectingLocation(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setDraft((prev) => ({
+          ...prev,
+          geo: { lat: pos.coords.latitude, lon: pos.coords.longitude },
+          locationMode: 'auto',
+        }));
+        setIsDetectingLocation(false);
+      },
+      () => {
+        showToast('Не удалось определить геолокацию, заполните город вручную');
+        setDraft((prev) => ({ ...prev, locationMode: 'manual', geo: undefined }));
+        setIsDetectingLocation(false);
+      },
+      { enableHighAccuracy: true, timeout: 8000 },
+    );
+  }, [draft.geo, draft.locationMode, isDetectingLocation, showToast]);
+
   const persistDraft = async (next: OnboardingDraft) => {
     try {
       await DeviceStorage.setJSON(DRAFT_KEY, next);
@@ -77,44 +190,153 @@ export default function OnboardingPage() {
     });
   };
 
+  const errors = useMemo(() => {
+    const currentErrors: Record<number, string[]> = {};
+
+    const age = calculateAge(draft.birthDate);
+    const baseErrors: string[] = [];
+    if (draft.name.trim().length < MIN_NAME_LENGTH) baseErrors.push('Имя должно быть не короче 2 символов.');
+    if (!draft.birthDate) baseErrors.push('Укажите дату рождения.');
+    if (age && age < MIN_AGE) baseErrors.push('Онбординг доступен пользователям старше 18 лет.');
+    if (!draft.gender) baseErrors.push('Выберите гендер.');
+    if (baseErrors.length) currentErrors[0] = baseErrors;
+
+    if (draft.photos.length === 0) currentErrors[1] = ['Добавьте хотя бы одно фото.'];
+
+    const preferencesErrors: string[] = [];
+    if (!draft.bio.trim()) preferencesErrors.push('Заполните описание о себе.');
+    if (!draft.interests.trim()) preferencesErrors.push('Укажите интересы.');
+    if (!draft.goals.trim()) preferencesErrors.push('Опишите цели знакомства.');
+    if (preferencesErrors.length) currentErrors[2] = preferencesErrors;
+
+    const locationErrors: string[] = [];
+    if (draft.locationMode === 'manual') {
+      if (!draft.city.trim()) locationErrors.push('Укажите город.');
+    } else if (!draft.geo) {
+      locationErrors.push('Не удалось определить геолокацию.');
+    }
+    if (!draft.radiusKm || draft.radiusKm < 5) locationErrors.push('Укажите радиус поиска (минимум 5 км).');
+    if (locationErrors.length) currentErrors[3] = locationErrors;
+
+    return currentErrors;
+  }, [draft]);
+
+  const isStepValid = (stepIndex: number) => !(stepIndex in errors);
+
   const handleNext = async () => {
-    const next = Math.min(draft.step + 1, steps.length - 1);
-    if (next !== draft.step) {
-      const updated = { ...draft, step: next };
+    const nextStep = Math.min(draft.step + 1, steps.length - 1);
+    if (!isStepValid(draft.step)) {
+      errors[draft.step]?.forEach((err) => showToast(err));
+      return;
+    }
+    if (nextStep !== draft.step) {
+      const updated = { ...draft, step: nextStep };
       setDraft(updated);
       await persistDraft(updated);
     }
   };
 
   const handleBack = async () => {
-    const prev = Math.max(draft.step - 1, 0);
-    if (prev !== draft.step) {
-      const updated = { ...draft, step: prev };
+    const prevStep = Math.max(draft.step - 1, 0);
+    if (prevStep !== draft.step) {
+      const updated = { ...draft, step: prevStep };
       setDraft(updated);
       await persistDraft(updated);
     }
   };
 
+  const handlePhotoUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    if (!files.length) return;
+    const remainingSlots = MAX_PHOTOS - draft.photos.length;
+    const acceptedFiles = files.slice(0, remainingSlots);
+    const photos: PhotoDraft[] = [];
+
+    for (const file of acceptedFiles) {
+      if (file.size > MAX_PHOTO_SIZE) {
+        showToast(`Файл ${file.name} превышает 1 MB и не будет добавлен.`);
+        continue;
+      }
+      try {
+        const dataUrl = await readFileAsDataUrl(file);
+        photos.push({
+          id: `${file.name}-${file.size}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+          name: file.name,
+          type: file.type || 'image/jpeg',
+          size: file.size,
+          dataUrl,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Не удалось прочитать файл';
+        showToast(message);
+      }
+    }
+
+    if (photos.length) {
+      updateDraft({ photos: [...draft.photos, ...photos] });
+    }
+    event.target.value = '';
+  };
+
+  const handleRemovePhoto = (id: string) => {
+    updateDraft({ photos: draft.photos.filter((photo) => photo.id !== id) });
+  };
+
+  const handleLocationModeToggle = (mode: LocationMode) => {
+    updateDraft({ locationMode: mode, geo: mode === 'auto' ? draft.geo : undefined });
+    if (mode === 'auto' && !draft.geo) {
+      setIsDetectingLocation(false);
+    }
+  };
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (!isStepValid(3)) {
+      errors[3]?.forEach((err) => showToast(err));
+      return;
+    }
     setIsSubmitting(true);
     try {
-      const response = await fetch('/api/onboarding/complete', {
+      const payload = {
+        name: draft.name.trim(),
+        birthDate: draft.birthDate,
+        gender: draft.gender,
+        bio: draft.bio.trim(),
+        interests: draft.interests.trim(),
+        goals: draft.goals.trim(),
+        radiusKm: draft.radiusKm,
+        location: draft.locationMode === 'auto' && draft.geo
+          ? { mode: 'auto', lat: draft.geo.lat, lon: draft.geo.lon }
+          : { mode: 'manual', city: draft.city.trim(), radiusKm: draft.radiusKm },
+      };
+
+      const response = await fetch('/api/profile/onboarding', {
         method: 'POST',
         headers: authHeaders,
-        body: JSON.stringify({
-          name: draft.name,
-          bio: draft.bio,
-          interests: draft.interests,
-          goals: draft.goals,
-        }),
+        body: JSON.stringify(payload),
       });
+
       if (!response.ok) {
-        throw new Error('Ошибка отправки анкеты');
+        throw new Error('Не удалось сохранить профиль.');
       }
+
+      for (const photo of draft.photos) {
+        const file = await dataUrlToFile(photo);
+        const formData = new FormData();
+        formData.append('file', file);
+        const uploadResponse = await fetch('/api/profile/media', {
+          method: 'POST',
+          headers: mediaHeaders,
+          body: formData,
+        });
+        if (!uploadResponse.ok) {
+          throw new Error(`Не удалось загрузить фото ${photo.name}`);
+        }
+      }
+
       await DeviceStorage.removeItem(DRAFT_KEY);
-      setDraft(defaultDraft);
-      showToast('Онбординг завершён');
+      showToast('Профиль создан!');
+      navigate('/');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Не удалось завершить онбординг';
       showToast(message);
@@ -125,75 +347,200 @@ export default function OnboardingPage() {
 
   const steps = [
     {
-      title: 'Расскажите о себе',
-      description: 'Как вас зовут и что вам нравится? Эти данные увидят будущие мэтчи.',
-      content: (
-        <fieldset className={styles.fieldset}>
+      title: 'Основные данные',
+      description: 'Расскажите о себе: имя, дата рождения и гендер видны только вам и используются для подбора мэтчей.',
+      render: (
+        <div className={styles.fieldset}>
           <label className={styles.label} htmlFor="name">
             Имя или никнейм
           </label>
           <input
             id="name"
             className={styles.input}
-            placeholder="Например, Анна"
             value={draft.name}
+            placeholder="Например, Юлия"
             onChange={(event) => updateDraft({ name: event.target.value })}
           />
-
+          <div className={styles.twoColumns}>
+            <div>
+              <label className={styles.label} htmlFor="birthDate">
+                Дата рождения
+              </label>
+              <input
+                id="birthDate"
+                className={styles.input}
+                type="date"
+                value={draft.birthDate}
+                max={new Date().toISOString().split('T')[0]}
+                onChange={(event) => updateDraft({ birthDate: event.target.value })}
+              />
+            </div>
+            <div>
+              <label className={styles.label} htmlFor="gender">
+                Пол
+              </label>
+              <select
+                id="gender"
+                className={styles.input}
+                value={draft.gender}
+                onChange={(event) => updateDraft({ gender: event.target.value as Gender })}
+              >
+                <option value="">Выберите</option>
+                <option value="female">Женский</option>
+                <option value="male">Мужской</option>
+                <option value="other">Другое</option>
+              </select>
+            </div>
+          </div>
+          {errors[0]?.map((err) => (
+            <p key={err} className={styles.error}>
+              {err}
+            </p>
+          ))}
+        </div>
+      ),
+      primaryActionLabel: 'Далее',
+    },
+    {
+      title: 'Добавьте фото',
+      description: 'Минимум одно фото. Чем больше — тем выше шанс получить ответный лайк.',
+      render: (
+        <div className={styles.fieldset}>
+          <div className={styles.photoGrid}>
+            {draft.photos.map((photo) => (
+              <div key={photo.id} className={styles.photoTile}>
+                <img src={photo.dataUrl} alt={photo.name} />
+                <button type="button" className={styles.photoRemove} onClick={() => handleRemovePhoto(photo.id)}>
+                  ✕
+                </button>
+              </div>
+            ))}
+            {draft.photos.length < MAX_PHOTOS && (
+              <label className={styles.photoUpload}>
+                <span>Загрузите {draft.photos.length ? 'ещё фото' : 'первое фото'}</span>
+                <span className={styles.badge}>до {MAX_PHOTOS}</span>
+                <input type="file" accept="image/*" multiple onChange={handlePhotoUpload} />
+              </label>
+            )}
+          </div>
+          {errors[1]?.map((err) => (
+            <p key={err} className={styles.error}>
+              {err}
+            </p>
+          ))}
+        </div>
+      ),
+      primaryActionLabel: 'Далее',
+    },
+    {
+      title: 'Интересы и цели',
+      description: 'Эта информация помогает подобрать совместимые анкеты и темы для начала общения.',
+      render: (
+        <div className={styles.fieldset}>
           <label className={styles.label} htmlFor="bio">
-            Расскажите о себе
+            О себе
           </label>
           <textarea
             id="bio"
             className={styles.textarea}
-            placeholder="Пара предложений о хобби, любимых местах или планах."
             rows={4}
+            placeholder="Пару предложений о том, чем занимаетесь и что любите."
             value={draft.bio}
             onChange={(event) => updateDraft({ bio: event.target.value })}
           />
-        </fieldset>
-      ),
-      primaryAction: (
-        <button type="button" className={styles.primary} onClick={handleNext}>
-          Далее
-        </button>
-      ),
-    },
-    {
-      title: 'Выберите интересы',
-      description: 'Поделитесь тем, что вас вдохновляет. Это поможет подобрать совместимые знакомства.',
-      content: (
-        <fieldset className={styles.fieldset}>
           <label className={styles.label} htmlFor="interests">
-            Интересы
+            Интересы (через запятую)
           </label>
           <textarea
             id="interests"
             className={styles.textarea}
-            placeholder="Например: походы, кулинария, стендап"
             rows={3}
+            placeholder="Например: серфинг, джаз, крафтовый кофе"
             value={draft.interests}
             onChange={(event) => updateDraft({ interests: event.target.value })}
           />
-
           <label className={styles.label} htmlFor="goals">
             Цели знакомства
           </label>
           <textarea
             id="goals"
             className={styles.textarea}
-            placeholder="Что вы ищете: общение, путешествия, серьёзные отношения"
             rows={3}
+            placeholder="Что вы ищете: общение, путешествия, серьёзные отношения"
             value={draft.goals}
             onChange={(event) => updateDraft({ goals: event.target.value })}
           />
-        </fieldset>
+          {errors[2]?.map((err) => (
+            <p key={err} className={styles.error}>
+              {err}
+            </p>
+          ))}
+        </div>
       ),
-      primaryAction: (
-        <button type="submit" className={styles.primary} disabled={isSubmitting}>
-          Завершить онбординг
-        </button>
+      primaryActionLabel: 'Далее',
+    },
+    {
+      title: 'География знакомств',
+      description: 'Уточните, где вы находитесь и на каком расстоянии готовы знакомиться.',
+      render: (
+        <div className={styles.fieldset}>
+          <div className={styles.twoColumns}>
+            <button
+              type="button"
+              className={styles.primary}
+              disabled={draft.locationMode === 'auto' && isDetectingLocation}
+              onClick={() => handleLocationModeToggle('auto')}
+            >
+              Использовать геолокацию
+            </button>
+            <button type="button" className={styles.secondary} onClick={() => handleLocationModeToggle('manual')}>
+              Указать вручную
+            </button>
+          </div>
+          {draft.locationMode === 'auto' ? (
+            <p className={styles.helper}>
+              {isDetectingLocation && 'Определяем ваше местоположение…'}
+              {!isDetectingLocation && draft.geo && `Определено: ${draft.geo.lat.toFixed(3)}, ${draft.geo.lon.toFixed(3)}`}
+              {!isDetectingLocation && !draft.geo && 'Не удалось определить координаты.'}
+            </p>
+          ) : (
+            <div className={styles.twoColumns}>
+              <div>
+                <label className={styles.label} htmlFor="city">
+                  Город
+                </label>
+                <input
+                  id="city"
+                  className={styles.input}
+                  value={draft.city}
+                  placeholder="Например, Екатеринбург"
+                  onChange={(event) => updateDraft({ city: event.target.value })}
+                />
+              </div>
+            </div>
+          )}
+          <div>
+            <label className={styles.label} htmlFor="radius">
+              Радиус поиска (км)
+            </label>
+            <input
+              id="radius"
+              className={styles.input}
+              type="number"
+              min={5}
+              max={200}
+              value={draft.radiusKm}
+              onChange={(event) => updateDraft({ radiusKm: Number(event.target.value) })}
+            />
+          </div>
+          {errors[3]?.map((err) => (
+            <p key={err} className={styles.error}>
+              {err}
+            </p>
+          ))}
+        </div>
       ),
+      primaryActionLabel: 'Завершить',
     },
   ];
 
@@ -212,10 +559,18 @@ export default function OnboardingPage() {
           ))}
         </div>
         <h1>{currentStep.title}</h1>
-        <p className={styles.helper}>{currentStep.description}</p>
-        {currentStep.content}
+        <p className={styles.stepCaption}>{currentStep.description}</p>
+        {currentStep.render}
         <div className={styles.actions}>
-          {currentStep.primaryAction}
+          {draft.step === steps.length - 1 ? (
+            <button type="submit" className={styles.primary} disabled={isSubmitting}>
+              {isSubmitting ? 'Сохраняем…' : currentStep.primaryActionLabel}
+            </button>
+          ) : (
+            <button type="button" className={styles.primary} onClick={handleNext}>
+              {currentStep.primaryActionLabel}
+            </button>
+          )}
           {draft.step > 0 && (
             <button type="button" className={styles.secondary} onClick={handleBack}>
               Назад
@@ -226,4 +581,3 @@ export default function OnboardingPage() {
     </form>
   );
 }
-


### PR DESCRIPTION
## Summary
- expand onboarding into four-step wizard with validation and progress UI
- add photo uploads, manual geolocation fallback, and Stars-aware copy
- integrate DeviceStorage drafts with file support and add vitest coverage

## Testing
- npm run lint
- npm run typecheck
- npm run test

Closes #58