### PR TITLE
chore(frontend): log audit results before Vite upgrade

### DIFF
--- a/docs/audit/npm-audit-logs-2025-09-25.md
+++ b/docs/audit/npm-audit-logs-2025-09-25.md
@@ -1,0 +1,27 @@
+# npm audit logs — 2025-09-25
+
+Актуальные результаты `npm audit --json` перед апгрейдом инструментов (#79 → #91).
+
+## apps/frontend
+| Пакет | Advisory | Severity | Диапазон | Фикс |
+|-------|----------|----------|----------|------|
+| esbuild | [GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99) | moderate | `<=0.24.2` | обновить transitively через `vite >= 7.1.7` |
+| vite | [GHSA-g4jq-h2w9-997c](https://github.com/advisories/GHSA-g4jq-h2w9-997c) | low | `<=5.4.19` | обновить `vite` до `7.1.7` |
+| vite | [GHSA-jqfw-vq24-v9c3](https://github.com/advisories/GHSA-jqfw-vq24-v9c3) | low | `<=5.4.19` | обновить `vite` до `7.1.7` |
+
+```
+$ cd apps/frontend
+$ npm audit --json > ../../tmp/frontend-audit-2025-09-25.json
+```
+
+## apps/miniapp-frontend
+| Пакет | Advisory | Severity | Диапазон | Фикс |
+|-------|----------|----------|----------|------|
+| esbuild | [GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99) | moderate | `<=0.24.2` | обновить `vite` до `7.1.7` |
+
+```
+$ cd apps/miniapp-frontend
+$ npm audit --json > ../../tmp/miniapp-frontend-audit-2025-09-25.json
+```
+
+> Полные JSON-логи сохранены локально в `tmp/` для дальнейших сравнений, но не включены в git.

--- a/docs/session-notes-2025-09-24.md
+++ b/docs/session-notes-2025-09-24.md
@@ -18,6 +18,7 @@
 - PR #99 (`feat(miniapp): apply theme tokens`) открыт для #77, все проверки (`lint`, `tests`, `typecheck`, `enable-auto-merge`) зелёные, авто-мерж завершился 25.09 после CI.
 - 25.09.2025 заведены новые issues: `docs/issues/issue-miniapp-design-tokens.md` (#77), `docs/issues/issue-miniapp-device-storage.md` (#78), `docs/issues/issue-frontend-vulnerabilities.md` (#79).
 - Под каждый из них созданы GitHub Sub-issues #80-#95 с лейблом `task` (токены, DeviceStorage стадии, апгрейд Vite).
+- Зафиксированы `npm audit --json` логи для `apps/frontend` и `apps/miniapp-frontend` (Issue #91) перед апгрейдом Vite; конспект в `docs/audit/npm-audit-logs-2025-09-25.md`.
 
 ## Сделано
 - Обновлён `main` до `89a88a2` и создана ветка `feature/issue-43-contributing-workflow`.


### PR DESCRIPTION
## Краткое описание
- выгрузил npm audit --json для apps/frontend и apps/miniapp-frontend
- задокументировал advisory и команды в docs/audit/npm-audit-logs-2025-09-25.md и обновил session notes

## Issue
Closes #91

## Чеклист
- [x] Обновлён `main` перед созданием ветки (`git checkout main && git pull`)
- [ ] Указаны результаты `mvn -f apps/backend/pom.xml test` — не требовалось
- [ ] Указаны результаты `npm run lint && npm run typecheck` — документация
- [ ] Добавлены/обновлены тесты, если изменена бизнес-логика
- [ ] Включён auto-merge после зелёных проверок
