### PR TITLE
chore(docs): capture vite upgrade runs

### DIFF
--- a/docs/issues/issue-frontend-vulnerabilities.md
+++ b/docs/issues/issue-frontend-vulnerabilities.md
@@ -8,11 +8,26 @@
 - Нужно выработать план обновления, прогнать тесты и убедиться, что конфигурации Vite/ESLint/Vitest продолжают работать после апгрейда.
 
 ## Задачи
-- [ ] #91 Зафиксировать текущие логи npm audit перед апгрейдом.
+- [x] #91 Зафиксировать текущие логи npm audit перед апгрейдом.
 - [ ] #92 Обновить зависимости miniapp-frontend до безопасных версий Vite/Vitest.
-- [ ] #93 Обновить зависимости основного фронтенда до безопасных версий Vite/Vitest.
-- [ ] #94 Задокументировать результаты прогонов и breaking changes после апгрейда.
+- [x] #93 Обновить зависимости основного фронтенда до безопасных версий Vite/Vitest.
+- [x] #94 Задокументировать результаты прогонов и breaking changes после апгрейда.
 - [ ] #95 Обновить README/доки и session notes после апгрейда.
+
+## Результаты прогонов (2025-09-25)
+- Дополнительных правок в `vite.config.ts`, Vitest конфигурации или ESLint не потребовалось — апгрейд `vite@7.1.7`, `vitest@3.2.4`, `typescript@5.9.2` собрался на штатных настройках.
+- `apps/frontend`:
+  - `npm run lint` — ✅
+  - `npm run typecheck` — ✅
+  - `npm run test` — ✅ (есть предупреждения `zustand` об устаревшем default export, планируется отдельный фикс)
+  - `npm run build` — ✅
+  - `npm audit` — ✅ (0 vulnerabilities)
+- `apps/miniapp-frontend`:
+  - `npm run lint` — ❌ (исторические typed-lint ошибки: `parserOptions.project` не покрывает `src/__tests__`, серия требований AirBnB по `react/function-component-definition`, `jsx-a11y/label-has-associated-control`, `no-console` и стилевые `comma-dangle`. Ошибка зафиксирована для последующего рефакторинга вместе с Issue #92.)
+  - `npm run test` — ✅
+  - `npm run build` — ✅
+
+> Итоги продублированы в PR по Issue #94.
 
 ## Критерии готовности
 - `npm audit` в `apps/frontend` и `apps/miniapp-frontend` завершает работу без уязвимостей.
@@ -24,4 +39,3 @@
 - `apps/miniapp-frontend/package.json`
 - Логи `npm audit --json` от 25.09.2025
 - `docs/session-notes-2025-09-24.md`
-

--- a/docs/session-notes-2025-09-24.md
+++ b/docs/session-notes-2025-09-24.md
@@ -20,6 +20,7 @@
 - Под каждый из них созданы GitHub Sub-issues #80-#95 с лейблом `task` (токены, DeviceStorage стадии, апгрейд Vite).
 - Зафиксированы `npm audit --json` логи для `apps/frontend` и `apps/miniapp-frontend` (Issue #91) перед апгрейдом Vite; конспект в `docs/audit/npm-audit-logs-2025-09-25.md`.
 - Обновлён основной фронтенд до Vite 7.1.7 / Vitest 3.2.4 / TypeScript 5.9.2 (Issue #93); `npm run lint`, `npm run typecheck`, `npm run test`, `npm run build` проходят, `npm audit` → 0.
+- Issue #94: задокументированы результаты прогонов для frontend/miniapp-frontend после апгрейда (см. `docs/issues/issue-frontend-vulnerabilities.md`).
 
 ## Сделано
 - Обновлён `main` до `89a88a2` и создана ветка `feature/issue-43-contributing-workflow`.


### PR DESCRIPTION
## Краткое описание
- добавил раздел с результатами прогонов (lint/typecheck/test/build/audit) в docs/issues/issue-frontend-vulnerabilities.md
- отметил завершение issue #94 и обновил session notes ссылкой на документ

## Issue
Closes #94

## Чеклист
- [x] Обновлён `main` перед созданием ветки (`git checkout main && git pull`)
- [ ] Указаны результаты `mvn -f apps/backend/pom.xml test` — не требовалось
- [ ] Указаны результаты `npm run lint && npm run typecheck` — документальное обновление
- [ ] Добавлены/обновлены тесты, если изменена бизнес-логика — не требовалось
- [ ] Включён auto-merge после зелёных проверок

### Заметки
- `npm run lint` в miniapp-frontend по-прежнему падает на исторических typed-lint ошибках; зафиксировал причины в документе, править планируем в рамках Issue #92.
