### PR TITLE
docs(miniapp): update device storage guidance

### DIFF
--- a/apps/miniapp-frontend/README.md
+++ b/apps/miniapp-frontend/README.md
@@ -14,6 +14,29 @@ React + Vite клиент Telegram Mini App для WAU Dating. Шаблон на
 - Глобальные стили и компоненты используют `var(--tg-...)`; для inline-стилей доступен хелпер `themeVar('color', 'text')`.
 - Fallback значения определены в `src/theme/base.css`, чтобы SSR/preview рендер имел корректную тему до инициализации Telegram SDK.
 
+## DeviceStorage
+- Черновики профиля и просмотренных матчей сохраняются через хелпер `withDeviceStorage` (`src/services/deviceStorage.ts`).
+- **Внутри Telegram**: если `window.Telegram.WebApp.CloudStorage` доступен, методы работы с черновиками используют облачное хранилище Telegram.
+- **Локально и в web preview**: автоматически включается fallback на `localStorage`.
+- CloudStorage ограничивает размер записи 1 MB. Перед сериализацией payload проверяется `TextEncoder().encode(value).length`.
+- Ошибки выводятся в консоль (`console.warn`/`console.error`) и пробрасываются вызывающему коду; витальные сценарии должны перехватывать их и показывать пользователю уведомления.
+
+### Как протестировать сохранение черновика
+
+1. Запустите mini app локально: `npm install && npm run dev`.
+2. Откройте `http://localhost:5174` в браузере. Вкладка «Профиль» будет использовать fallback на `localStorage`.
+3. Чтобы проверить CloudStorage, опубликуйте билд на адрес, который добавлен в `BotFather` → `menuButton` → `web_app`. Заполните `.env` переменные `BOT_TOKEN`, `TELEGRAM_WEBAPP_URL` и перезапустите backend/gateway.
+4. В Telegram (Desktop/Mobile) откройте WebApp. В DevTools (`Cmd+Option+J` на Desktop) выполните:
+   ```js
+   Telegram.WebApp.CloudStorage.getItem('wau:profile-draft', console.log)
+   ```
+   Должен вернуться JSON с черновиком профиля.
+
+### Отладка
+- Для форсированного fallback удалите объект `Telegram.WebApp.CloudStorage` в консоли и повторите действия: приложение должно переключиться на `localStorage` без ошибок.
+- При ошибках CloudStorage обёртки выбросят `DeviceStorageError` — оберните вызовы в `try/catch` и логируйте `error.message`.
+- Чтобы очистить черновики, используйте `localStorage.removeItem('wau:profile-draft')` или `Telegram.WebApp.CloudStorage.removeItem` внутри WebApp.
+
 ## TODO
 - Подключить реальные API через gateway.
 - Реализовать экраны onboarding, swipe deck, paywall.

--- a/docs/issues/issue-miniapp-device-storage.md
+++ b/docs/issues/issue-miniapp-device-storage.md
@@ -13,7 +13,7 @@
 - [ ] #87 Ограничить размер записей 1 MB и выдавать ошибки.
 - [ ] #88 Логировать ошибки DeviceStorage через trackEvent.
 - [ ] #89 Покрыть DeviceStorage Vitest-тестами (успех/ошибка/fallback).
-- [ ] #90 Обновить документацию и session notes по DeviceStorage.
+- [x] #90 Обновить документацию и session notes по DeviceStorage.
 
 ## Критерии готовности
 - При запуске внутри Telegram WebApp черновики сохраняются и восстанавливаются через Telegram CloudStorage; локально всё работает через fallback без ошибок.
@@ -28,4 +28,3 @@
 - `apps/miniapp-frontend/src/utils/analytics.ts`
 - Документы Telegram Mini App CloudStorage
 - `docs/session-notes-2025-09-24.md`
-

--- a/docs/runbooks/device-storage-debug.md
+++ b/docs/runbooks/device-storage-debug.md
@@ -1,0 +1,45 @@
+# Runbook — DeviceStorage Debug
+
+Дата актуальности: 25 сентября 2025.
+
+## Сценарии
+- **Telegram WebApp (боевой)** — хранилище `Telegram.WebApp.CloudStorage` (лимит 1 MB на ключ).
+- **Локальная разработка / Vite preview** — fallback к `window.localStorage`.
+
+## Быстрый чекап
+1. Откройте мини-апп в нужном окружении.
+2. В DevTools выполните `Telegram.WebApp.CloudStorage?.isAvailable` (должно вернуть `true`).
+3. Если `false`/`undefined`, приложение должно логировать `console.warn('CloudStorage API недоступен')` и работать через localStorage.
+
+## Диагностика проблем
+| Симптом | Проверка | Действие |
+| --- | --- | --- |
+| Черновики не сохраняются внутри Telegram | `Telegram.WebApp.CloudStorage.getItem('wau:profile-draft', console.log)` → `null` | Убедитесь, что мини-апп открыта по URL из BotFather и пользователь дал `write_access`. |
+| Ошибка `DeviceStorageError: Размер данных превышает 1 MB лимит CloudStorage` | `new TextEncoder().encode(JSON.stringify(payload)).length` > 1_048_576 | Уменьшите размер сериализуемого состояния (обрезать фото/большие массивы). |
+| В консоли `CloudStorage API недоступен` | `Telegram.WebApp.CloudStorage` отсутствует | Запустите внутри Telegram Desktop/Mobile; в браузере fallback штатный. |
+| Fallback не срабатывает локально | `window.localStorage` недоступен (Safari Private, etc.) | Запустите в режиме без Private или используйте стейджинг в Telegram. |
+
+## Окружение и переменные
+- `.env`:
+  - `BOT_TOKEN` — токен бота, используемый для авторизации и выставления WebApp.
+  - `TELEGRAM_WEBAPP_URL` — публичный URL, зарегистрированный в BotFather (ngrok/Cloudflare Tunnel).
+  - `JWT_SECRET` — требуется backend’у для подписи токенов (без него профили не загрузятся).
+- Для локального fallback достаточно `npm run dev`; CloudStorage проявится только в официальном клиенте Telegram.
+
+## Полезные команды
+```js
+// Проверка доступности CloudStorage
+typeof Telegram?.WebApp?.CloudStorage !== 'undefined'
+
+// Принудительная очистка черновика
+Telegram.WebApp.CloudStorage.removeItem('wau:profile-draft', console.log)
+
+// Логирование размеров
+const draft = localStorage.getItem('wau:profile-draft');
+new TextEncoder().encode(draft ?? '').length;
+```
+
+## Ссылки
+- `apps/miniapp-frontend/src/services/deviceStorage.ts`
+- Telegram Docs — [CloudStorage](https://core.telegram.org/bots/webapps#cloudstorage)
+- Issue #78 и подзадачи #85–#90

--- a/docs/session-notes-2025-09-24.md
+++ b/docs/session-notes-2025-09-24.md
@@ -23,6 +23,7 @@
 - Issue #94: задокументированы результаты прогонов для frontend/miniapp-frontend после апгрейда (см. `docs/issues/issue-frontend-vulnerabilities.md`).
 - Issue #95: обновлены требования к Node.js (README, onboarding), session notes ссылаются на `npm audit`.
 - Issue #92: miniapp-frontend переведён на Vite 7.1.7 / Vitest 3.2.4 / TypeScript 5.9.2, ESLint/tsconfig поправлены, `npm run lint`, `npm run test`, `npm run build`, `npm audit` проходят.
+- Issue #90: обновлены инструкции по DeviceStorage (`apps/miniapp-frontend/README.md`, `docs/runbooks/device-storage-debug.md`), session notes дополнили статусы.
 
 ## Сделано
 - Обновлён `main` до `89a88a2` и создана ветка `feature/issue-43-contributing-workflow`.


### PR DESCRIPTION
## Краткое описание
- добавил секцию "DeviceStorage" в `apps/miniapp-frontend/README.md` с шагами тестирования CloudStorage и fallback
- создал runbook `docs/runbooks/device-storage-debug.md` (диагностика, лимиты, окружение)
- отметки в session notes и issue log (#78) обновлены под выполненный таск

## Issue
Closes #90

## Чеклист
- [x] Обновлён `main` перед созданием ветки (`git checkout main && git pull`)
- [ ] Указаны результаты `mvn -f apps/backend/pom.xml test` — не требовались
- [ ] Указаны результаты `npm run lint && npm run typecheck` — документация
- [ ] Добавлены/обновлены тесты, если изменена бизнес-логика — не требовалось
- [ ] Включён auto-merge после зелёных проверок
