### PR TITLE
feat(miniapp): surface device storage limit errors

### DIFF
--- a/apps/miniapp-frontend/src/__tests__/deviceStorage.test.ts
+++ b/apps/miniapp-frontend/src/__tests__/deviceStorage.test.ts
@@ -10,6 +10,7 @@ import type { CloudStorage } from '@tma.js/sdk';
 import { initCloudStorage } from '@tma.js/sdk';
 import DeviceStorage, {
   DeviceStorageError,
+  DEVICE_STORAGE_LIMIT_BYTES,
   __internal as deviceStorageInternal,
   withDeviceStorage,
 } from '../services/deviceStorage';
@@ -157,7 +158,11 @@ describe('DeviceStorage (miniapp)', () => {
 
   it('validates payload size', async () => {
     const oversized = 'x'.repeat(1024 * 1024 + 1);
-    await expect(DeviceStorage.setItem('oversized', oversized)).rejects.toThrow(DeviceStorageError);
+    await expect(DeviceStorage.setItem('oversized', oversized)).rejects.toMatchObject({
+      name: 'DeviceStorageError',
+      code: 'PAYLOAD_TOO_LARGE',
+      message: `Размер данных превышает ${DEVICE_STORAGE_LIMIT_BYTES / (1024 * 1024)} MB лимит CloudStorage`,
+    });
   });
 
   it('allows adapters through withDeviceStorage helper', async () => {

--- a/apps/miniapp-frontend/src/__tests__/matchStore.test.ts
+++ b/apps/miniapp-frontend/src/__tests__/matchStore.test.ts
@@ -1,0 +1,60 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import DeviceStorage, { DeviceStorageError } from '../services/deviceStorage';
+import { useMatchStore } from '../store/match';
+
+vi.mock('../api/notifications', () => ({
+  sendMatchInvite: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+describe('useMatchStore', () => {
+  let getJsonSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getJsonSpy = vi.spyOn(DeviceStorage, 'getJSON').mockResolvedValue(null);
+    useMatchStore.setState({
+      activeMatch: null,
+      hydrated: false,
+      seenKeys: new Set<string>(),
+    });
+  });
+
+  afterEach(() => {
+    getJsonSpy.mockRestore();
+    useMatchStore.setState({
+      activeMatch: null,
+      hydrated: false,
+      seenKeys: new Set<string>(),
+    });
+  });
+
+  it('reverts seen keys when CloudStorage overflows', async () => {
+    const limitError = new DeviceStorageError('Размер данных превышает 1 MB лимит CloudStorage', {
+      code: 'PAYLOAD_TOO_LARGE',
+    });
+    const setJsonSpy = vi.spyOn(DeviceStorage, 'setJSON').mockRejectedValueOnce(limitError);
+
+    await useMatchStore.getState().presentMatch({
+      matchId: 'match-1',
+      targetTelegramId: 123,
+      name: 'Test',
+      createdAt: new Date().toISOString(),
+    });
+
+    const state = useMatchStore.getState();
+    expect(state.seenKeys.size).toBe(0);
+    expect(setJsonSpy).toHaveBeenCalled();
+
+    setJsonSpy.mockRestore();
+  });
+});

--- a/apps/miniapp-frontend/src/__tests__/profileStore.test.ts
+++ b/apps/miniapp-frontend/src/__tests__/profileStore.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DeviceStorage, { DeviceStorageError } from '../services/deviceStorage';
+import { useProfileStore } from '../store/profile';
+
+describe('useProfileStore', () => {
+  const defaultDraft = {
+    displayName: '',
+    bio: '',
+    interests: [] as string[],
+  };
+
+  beforeEach(() => {
+    useProfileStore.setState({
+      profile: null,
+      draft: { ...defaultDraft },
+      status: 'ready',
+      error: undefined,
+    });
+  });
+
+  it('surfaces payload-too-large errors when persisting draft', async () => {
+    const limitError = new DeviceStorageError('Размер данных превышает 1 MB лимит CloudStorage', {
+      code: 'PAYLOAD_TOO_LARGE',
+    });
+    const setJsonSpy = vi.spyOn(DeviceStorage, 'setJSON').mockRejectedValueOnce(limitError);
+
+    await useProfileStore.getState().updateDraft({ bio: 'new bio' });
+
+    const state = useProfileStore.getState();
+    expect(state.status).toBe('error');
+    expect(state.error).toMatch(/лимит/i);
+    expect(state.draft).toEqual(defaultDraft);
+
+    setJsonSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add structured DeviceStorageError metadata and exported 1 MB limit constants
- surface payload-too-large failures in profile/match stores with user messaging and rollback
- extend vitest coverage for overflow handling across services and stores

## Testing
- npm run test

Closes #87