### PR TITLE
feat(miniapp): track device storage failures

### DIFF
--- a/apps/miniapp-frontend/src/utils/analytics.ts
+++ b/apps/miniapp-frontend/src/utils/analytics.ts
@@ -5,7 +5,8 @@ export type AnalyticsEvent =
   | 'swipe_dislike'
   | 'swipe_undo'
   | 'swipe_match'
-  | 'match_shown';
+  | 'match_shown'
+  | 'device_storage_error';
 
 export function trackEvent(event: AnalyticsEvent, payload?: Record<string, unknown>) {
   console.info('[analytics]', event, payload ?? {});


### PR DESCRIPTION
## Summary
- add analytics event  and instrument DeviceStorage fallbacks
- capture payload limit validation and JSON parse failures with contextual metadata
- ensure tests assert analytics logging for overflow/fallback scenarios

## Testing
- npm run test

Closes #88