### PR TITLE
fix(railway): align runtime entrypoints

### DIFF
--- a/apps/backend/railway.json
+++ b/apps/backend/railway.json
@@ -8,7 +8,7 @@
     "buildCommand": "mvn -DskipTests package"
   },
   "deploy": {
-    "startCommand": "java -jar target/backend-0.1.0.jar",
+    "startCommand": "java -jar app.jar",
     "healthcheckPath": "/actuator/health",
     "overlapSeconds": 30
   }

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -11,4 +11,4 @@ ENV NODE_ENV=production
 RUN npm install --global serve@14
 COPY --from=build /app/dist ./dist
 EXPOSE 4173
-CMD ["sh", "-c", "serve -s dist -l 0.0.0.0:${PORT:-4173}"]
+CMD ["sh", "-c", "serve -s dist -l tcp://0.0.0.0:${PORT:-4173}"]

--- a/apps/miniapp-frontend/Dockerfile
+++ b/apps/miniapp-frontend/Dockerfile
@@ -11,4 +11,4 @@ ENV NODE_ENV=production
 RUN npm install --global serve@14
 COPY --from=build /app/dist ./dist
 EXPOSE 4173
-CMD ["sh", "-c", "serve -s dist -l 0.0.0.0:${PORT:-4173}"]
+CMD ["sh", "-c", "serve -s dist -l tcp://0.0.0.0:${PORT:-4173}"]

--- a/apps/miniapp-gateway/Dockerfile
+++ b/apps/miniapp-gateway/Dockerfile
@@ -12,4 +12,4 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
 EXPOSE 3000
-CMD ["npm", "run", "start"]
+CMD ["node", "dist/main/main.js"]

--- a/apps/miniapp-gateway/package.json
+++ b/apps/miniapp-gateway/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "start": "node dist/main.js",
+    "start": "node dist/main/main.js",
     "start:dev": "nest start --watch",
     "build": "nest build",
     "lint": "eslint 'src/**/*.{ts,tsx}'"

--- a/apps/miniapp-gateway/railway.json
+++ b/apps/miniapp-gateway/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "npm ci && npm run build"
   },
   "deploy": {
-    "startCommand": "node dist/main.js",
+    "startCommand": "node dist/main/main.js",
     "healthcheckPath": "/health"
   }
 }


### PR DESCRIPTION
## Summary
- point backend runtime to built app.jar so healthcheck succeeds
- ensure frontend/minapp frontends pass a valid --listen URL to serve
- run miniapp gateway from dist/main/main.js after Nest build

## Testing
- mvn -f apps/backend/pom.xml -DskipTests package
- npm --prefix apps/frontend run build
- npm --prefix apps/miniapp-frontend run build
- npm --prefix apps/miniapp-gateway run build
