### PR TITLE
fix(railway): let backend Docker entrypoint launch app

### DIFF
--- a/apps/backend/railway.json
+++ b/apps/backend/railway.json
@@ -8,7 +8,6 @@
     "buildCommand": "mvn -DskipTests package"
   },
   "deploy": {
-    "startCommand": "java -jar app.jar",
     "healthcheckPath": "/actuator/health",
     "overlapSeconds": 30
   }


### PR DESCRIPTION
## Summary
- удалил startCommand из apps/backend/railway.json, теперь Railway использует ENTRYPOINT из Dockerfile
- Dockerfile уже запускает java -jar app.jar, что соответствует артефакту внутри образа

## Testing
- mvn -f apps/backend/pom.xml -DskipTests package
- npm --prefix apps/frontend run build
- npm --prefix apps/miniapp-frontend run build
- npm --prefix apps/miniapp-gateway run build
