### PR TITLE
fix(lquibase): correct chat_messages changelog indentation

### DIFF
--- a/apps/backend/src/main/resources/db/changelog/db.changelog-master.yml
+++ b/apps/backend/src/main/resources/db/changelog/db.changelog-master.yml
@@ -247,11 +247,11 @@ databaseChangeLog:
                   type: TEXT
                   constraints:
                     nullable: false
-                - column:
-                    name: created_at
-                    type: TIMESTAMP WITH TIME ZONE
-                    constraints:
-                      nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP WITH TIME ZONE
+                  constraints:
+                    nullable: false
         - createIndex:
             tableName: chat_messages
             indexName: idx_chat_match_created


### PR DESCRIPTION
## Summary
- включил goal `repackage` в spring-boot-maven-plugin, чтобы Railway получал исполняемый JAR
- поправил отступы в changeSet chat_messages (Liquibase больше не падает на YAML)
- объявил зависимость `core-backend` -> `PostgreSQL` в railway.json, чтобы Railway поднимал базу раньше и рисовал связь

## Testing
- mvn -f apps/backend/pom.xml -DskipTests package
